### PR TITLE
Ignore le dossier de tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,4 +52,6 @@ jobs:
         run: "${{ env.COMPOSER_UP }}"
 
       - name: Run the static tools with grumphp
-        run: "php vendor/bin/grumphp run --no-interaction"
+        run: |
+          mkdir tests
+          php vendor/bin/grumphp run --no-interaction

--- a/README.md
+++ b/README.md
@@ -35,3 +35,17 @@ Il est donc possible de personnaliser chaque fichier de configuration.
 
 Cette commande `php vendor/bin/grumphp run` execute donc tous les outils en 
 parallèle, mais uniquement pour les modifications qui seront validées.
+
+## Suppression des avertissements
+
+Dans certains cas, il est préférable d'ignorer les avertissements.  
+Excepté pour [PHPMD - PHP Mess Detector](https://phpmd.org/) il est conseillé 
+d'ignorer les avertissements dans les fichiers de configuration :
+
+- [PHPMD](https://phpmd.org/documentation/suppress-warnings.html)
+- [PHPStan](https://phpstan.org/user-guide/ignoring-errors#ignoring-in-configuration-file)
+- [Psalm](https://psalm.dev/docs/running_psalm/dealing_with_code_issues/#config-suppression)
+
+Ignorer les avertissements dans les fichiers de configuration permet de ne pas
+ajouter du code spécifique pour les outils d'analyses statiques.  
+Si vous décidez d'en supprimer un, votre code restera propre.

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -9,4 +9,5 @@ grumphp:
             ruleset: ['./pmd-ruleset.xml']
         phpstan:
             configuration: './phpstan.neon'
+            use_grumphp_paths: false
         psalm: ~

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -36,4 +36,5 @@
     <exclude-pattern>*Monolog*</exclude-pattern>
     <exclude-pattern>*Version*</exclude-pattern>
     <exclude-pattern>*src/Kernel.php</exclude-pattern>
+    <exclude-pattern>tests/*</exclude-pattern>
 </ruleset>

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,7 @@
         <directory name="src" />
         <ignoreFiles>
             <directory name="vendor" />
+            <directory name="tests" />
         </ignoreFiles>
     </projectFiles>
 </psalm>


### PR DESCRIPTION
Plusieurs petites modifications :  

- On ignore le dossier "tests" dans les configuration de `PHPMD`, `phpstan` et `psalm`. On garde les modifications pour `PHP CS Fixer`.
- On met l'option `use_grumphp_paths` à false. Cela permet de forcer l'utilisation du fichier de configuration pour la vérification des fichiers plutôt que celle de grumph et donc d'ignorer le dossier `tests`.
- Ajoute de la documentation sur `Comment ignorer les avertissements` des outils. Un lien rapide pour trouver directement la bonne page.