### PR TITLE
Fix composer install file method

### DIFF
--- a/src/Composer/InstallFilesPlugin.php
+++ b/src/Composer/InstallFilesPlugin.php
@@ -15,11 +15,6 @@ use Composer\Plugin\PluginInterface;
 use PHPStaticAnalysisTool\Exception\PathNotFound;
 use Symfony\Component\Filesystem\Filesystem;
 
-/**
- * @psalm-suppress MissingConstructor
- *
- * @psalm-api
- */
 class InstallFilesPlugin implements EventSubscriberInterface, PluginInterface
 {
     public const PACKAGE_NAME = 'assurance-maladie/qualytou';
@@ -29,7 +24,6 @@ class InstallFilesPlugin implements EventSubscriberInterface, PluginInterface
         '.php-cs-fixer.dist.php',
         'phpstan.neon',
         'pmd-ruleset.xml',
-        'psalm.xml',
     ];
 
     /** @var Composer */


### PR DESCRIPTION
Depuis la suppression de psalm, il n'est plus possible d'installer le bundle car il manque le fichier de configuration psalm.
J'ai donc supprimé la configuration de ce bundle.

![image](https://github.com/assurance-maladie-digital/qualytou/assets/8134250/83374a6f-4122-42e8-aaf8-d5a925fdf65f)
